### PR TITLE
Fix interactive prompts in chia.sh script

### DIFF
--- a/chia.sh
+++ b/chia.sh
@@ -140,12 +140,12 @@ if [[ ! -f "$SSH_KEY_PATH" ]]; then
     log "  • Authenticate with remote servers"
     log ""
 
-    read -p "Would you like to generate an SSH key now? [Y/n]: " -n 1 -r
+    read -p "Would you like to generate an SSH key now? [Y/n]: " -n 1 -r < /dev/tty
     echo
 
     if [[ ! $REPLY =~ ^[Nn]$ ]]; then
         log ""
-        read -p "Enter your email address for the SSH key: " email
+        read -p "Enter your email address for the SSH key: " email < /dev/tty
 
         if [[ -z "$email" ]]; then
             handle_error "Email address is required for SSH key generation"
@@ -184,7 +184,7 @@ if [[ ! -f "$SSH_KEY_PATH" ]]; then
         eval "$(ssh-agent -s)" > /dev/null
         ssh-add "$SSH_KEY_PATH" 2>/dev/null || true
 
-        read -p "Press Enter when you've added the key to GitHub to continue..."
+        read -p "Press Enter when you've added the key to GitHub to continue..." < /dev/tty
         echo
     else
         log ""


### PR DESCRIPTION
When running via curl | bash, stdin is connected to curl's output rather than the terminal, which causes read commands to fail silently and not wait for user input.

Fixed by redirecting all interactive read prompts to /dev/tty:
- SSH key generation prompt
- Email address input
- "Press Enter to continue" prompt

This ensures the script properly waits for user input even when executed via: curl https://...chia.sh | bash