### PR TITLE
Debug and identify root cause

### DIFF
--- a/macos-tools/install-rust.sh
+++ b/macos-tools/install-rust.sh
@@ -21,7 +21,7 @@ RUST_COMPONENTS=${RUST_COMPONENTS:-$DEFAULT_COMPONENTS}
 
 # Install Rust using rustup
 install_rust() {
-    run_with_logging "Installing Rust" curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+    run_with_logging "Installing Rust" sh -c "curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y"
     if [ $? -ne 0 ]; then
         exit 1
     fi


### PR DESCRIPTION
The curl | sh pipeline was being executed incorrectly. The pipe operator had higher precedence than the function call, causing run_with_logging to capture curl's output while the log message was piped to sh.

This resulted in the error: "sh: line 1: [2025-11-22: command not found" because sh was trying to execute the log timestamp as a command.

Solution: Wrap the entire pipeline in 'sh -c' so it executes as a single command within run_with_logging, matching the pattern used for Homebrew installation in chia.sh.