### PR TITLE
Fix shift-enter key handling in Ghostty

### DIFF
--- a/chia.sh
+++ b/chia.sh
@@ -253,6 +253,7 @@ pushd ~/workspace/chia > /dev/null
     run_with_logging "Installing zsh configuration" stow -t $HOME zsh || handle_error "Failed to install zsh configuration"
     run_with_logging "Installing git configuration" stow -t $HOME git || handle_error "Failed to install git configuration"
     run_with_logging "Installing ruby configuration" stow -t $HOME ruby || handle_error "Failed to install ruby configuration"
+    run_with_logging "Installing ghostty configuration" stow -t $HOME ghostty || handle_error "Failed to install ghostty configuration"
 
     # Source the new environment
     run_quiet source $HOME/.zshenv || true

--- a/ghostty/config
+++ b/ghostty/config
@@ -1,0 +1,24 @@
+# Ghostty Terminal Configuration
+# This config is managed by chia and installed via GNU stow to ~/.config/ghostty/config
+
+# ============================================================================
+# Shift+Enter Key Binding Fix
+# ============================================================================
+#
+# Issue: Ghostty implements the modern "modifyOtherKeys" terminal standard,
+# which sends the escape sequence [27;2;13~ for Shift+Enter. While this
+# provides more precise key information, many applications and shells don't
+# yet recognize this modern sequence and display raw characters: ;2;13~
+#
+# Solution: Configure Ghostty to send the legacy escape sequence \x1b\r
+# that is widely recognized by shells like zsh and applications.
+#
+# References:
+# - https://github.com/ghostty-org/ghostty/issues/1850
+# - https://github.com/ghostty-org/ghostty/discussions/5368
+# - https://github.com/anthropics/claude-code/issues/5757
+# - https://ghostty.org/docs/config/keybind
+#
+# This ensures Shift+Enter inserts a newline in terminal prompts and
+# applications, matching behavior from macOS Terminal and other terminals.
+keybind = shift+enter=text:\x1b\r


### PR DESCRIPTION
Ghostty implements the modern modifyOtherKeys terminal standard which sends escape sequence [27;2;13~ for Shift+Enter. This causes the raw characters ;2;13~ to appear instead of inserting a newline.

Solution:
- Created ghostty/config with keybind to send legacy escape sequence
- Updated chia.sh to stow Ghostty configuration automatically
- Added comprehensive documentation with references

The configuration tells Ghostty to send \x1b\r for Shift+Enter, which is widely recognized by shells and applications.

References:
- https://github.com/ghostty-org/ghostty/issues/1850
- https://github.com/ghostty-org/ghostty/discussions/5368
- https://github.com/anthropics/claude-code/issues/5757