### PR TITLE
Remove Claude Code CLI installation from Node.js setup

### DIFF
--- a/macos-tools/install-nodes.sh
+++ b/macos-tools/install-nodes.sh
@@ -9,4 +9,3 @@ mkdir -p ~/.nvm
 source "${HOMEBREW_PREFIX}/opt/nvm/nvm.sh"
 run_with_logging "Installing Node.js 22" nvm install 22 || log "Warning: Failed to install Node.js 22"
 run_with_logging "Setting Node.js 22 as default" nvm alias default 22 || log "Warning: Failed to set default Node.js version"
-run_with_logging "Installing Claude Code CLI" npm install -g @anthropic-ai/claude-code || log "Warning: Failed to install Claude Code CLI"


### PR DESCRIPTION
## Summary
Removed the automatic installation of the Claude Code CLI package from the Node.js setup script.

## Changes
- Removed the `npm install -g @anthropic-ai/claude-code` command from the macOS Node.js installation script
- This package will no longer be automatically installed when setting up Node.js 22

## Rationale
The Claude Code CLI installation has been decoupled from the Node.js setup process. Users who need this package can install it separately if required, allowing for more flexible and modular tooling setup.

https://claude.ai/code/session_015NwcqqFwGWqVAt1P553Rsm