### PR TITLE
Add Claude cask and Codex npm package to development setup

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -1,4 +1,5 @@
 cask 'antigravity'
+cask 'claude'
 cask 'claude-code'
 cask 'discord'
 cask 'docker'

--- a/macos-tools/install-nodes.sh
+++ b/macos-tools/install-nodes.sh
@@ -9,3 +9,5 @@ mkdir -p ~/.nvm
 source "${HOMEBREW_PREFIX}/opt/nvm/nvm.sh"
 run_with_logging "Installing Node.js 22" nvm install 22 || log "Warning: Failed to install Node.js 22"
 run_with_logging "Setting Node.js 22 as default" nvm alias default 22 || log "Warning: Failed to set default Node.js version"
+
+run_with_logging "Installing Codex" npm install -g @openai/codex || log "Warning: Failed to install Codex"


### PR DESCRIPTION
## Summary
This PR updates the development environment setup by adding the Claude application to the Homebrew cask list and installing the OpenAI Codex npm package globally during Node.js setup.

## Changes
- **Brewfile**: Added `cask 'claude'` to the list of applications to install via Homebrew
- **macos-tools/install-nodes.sh**: Added installation of `@openai/codex` npm package globally after Node.js 22 setup completes

## Details
The Claude cask installation complements the existing `claude-code` cask, providing the main Claude application alongside the code editor integration. The Codex npm package is installed as part of the Node.js setup workflow to ensure it's available in the global npm environment for development purposes. Both installations include appropriate error logging to warn if they fail without blocking the overall setup process.

https://claude.ai/code/session_01UU3KCJfU4zYcmYVCy14CyC